### PR TITLE
タグ名変更時に更新されるように修正

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -462,7 +462,7 @@ function TemplateModal({ isOpen, onClose }: ModalProps) {
 }
 
 function TagModal({ isOpen, onClose }: ModalProps) {
-  const { tags, setTags, setAlertMessage } = useAppContext();
+  const { tags, setTags, transactionsByMonth, setTransactionsByMonth, templates, setTemplates, setAlertMessage } = useAppContext();
   const [editingName, setEditingName] = useState<string | null>(null);
   const [name, setName] = useState('');
   const [color, setColor] = useState('');
@@ -499,6 +499,17 @@ function TagModal({ isOpen, onClose }: ModalProps) {
       setTags([...tags, tagData]);
     } else {
       setTags(tags.map(t => t.name === editingName ? tagData : t));
+      // タグ名が変更された場合、トランザクションとテンプレートのタグ名も更新
+      if (editingName !== name) {
+        const updatedTransactions = Object.fromEntries(
+          Object.entries(transactionsByMonth).map(([key, txns]) => [
+            key,
+            txns.map(t => t.tag === editingName ? { ...t, tag: name } : t)
+          ])
+        );
+        setTransactionsByMonth(updatedTransactions);
+        setTemplates(templates.map(t => t.tag === editingName ? { ...t, tag: name } : t));
+      }
     }
     resetForm();
   };


### PR DESCRIPTION
## やったこと
<!-- このPRで何をしたのか？ -->
タグ名変更時に該当箇所を更新するように修正。

## 概要
<!-- PRの背景・目的・概要 -->
タグ名を変更したときに収支とテンプレートがそのままだったため、表示はされるが想定道理の挙動をしなかった。

<!-- ## 備考（任意） -->
<!-- レビュワーへの伝達事項や残しておきたい情報 -->

## 関連
<!-- 関連するIssueやチケットのリンクを貼る -->
fix #4